### PR TITLE
possible alternative to emit_que

### DIFF
--- a/src/psygnal/_signal.py
+++ b/src/psygnal/_signal.py
@@ -299,9 +299,6 @@ class SignalInstance:
         Whether to check the callback parameter types against `signature` when
         connecting a new callback. This can also be provided at connection time using
         `.connect(..., check_types=True)`. By default, False.
-    raise_on_emit_during_emission: bool
-        raise exception if signal is emitted while already emitting.
-        This could be used to detect callback loops. By default, False.
 
     Raises
     ------
@@ -322,7 +319,6 @@ class SignalInstance:
         name: str | None = None,
         check_nargs_on_connect: bool = True,
         check_types_on_connect: bool = False,
-        raise_on_emit_during_emission: bool = False,
     ) -> None:
         self._name = name
         self._instance: Callable = self._instance_ref(instance)
@@ -339,7 +335,6 @@ class SignalInstance:
         self._signature = signature
         self._check_nargs_on_connect = check_nargs_on_connect
         self._check_types_on_connect = check_types_on_connect
-        self._raise_on_emit_during_emission = raise_on_emit_during_emission
         self._slots: list[WeakCallback] = []
         self._is_blocked: bool = False
         self._is_paused: bool = False

--- a/src/psygnal/containers/_evented_list.py
+++ b/src/psygnal/containers/_evented_list.py
@@ -413,7 +413,6 @@ class EventedList(MutableSequence[_T]):
             idx = self.index(obj)
         except ValueError:  # pragma: no cover
             return
-
         if (
             args
             and isinstance(emitter, SignalRelay)

--- a/src/psygnal/containers/_evented_list.py
+++ b/src/psygnal/containers/_evented_list.py
@@ -413,6 +413,7 @@ class EventedList(MutableSequence[_T]):
             idx = self.index(obj)
         except ValueError:  # pragma: no cover
             return
+
         if (
             args
             and isinstance(emitter, SignalRelay)

--- a/tests/test_psygnal.py
+++ b/tests/test_psygnal.py
@@ -1,5 +1,4 @@
 import gc
-import time
 from contextlib import suppress
 from functools import partial, wraps
 from inspect import Signature
@@ -9,7 +8,7 @@ from unittest.mock import MagicMock, Mock, call
 import pytest
 import toolz
 
-from psygnal import EmitLoopError, Signal, SignalInstance, _compiled
+from psygnal import EmitLoopError, Signal, SignalInstance
 from psygnal._weak_callback import WeakCallback
 
 
@@ -583,34 +582,6 @@ def test_unique_connections():
     assert len(e.one_int._slots) == 2
 
 
-@pytest.mark.skipif(_compiled, reason="passes, but segfaults on exit")
-def test_asynchronous_emit():
-    e = Emitter()
-    a = []
-
-    def slow_append(arg: int):
-        time.sleep(0.1)
-        a.append(arg)
-
-    mock = MagicMock(wraps=slow_append)
-    e.no_arg.connect(mock, unique=False)
-
-    assert not Signal.current_emitter()
-    value = 42
-    with pytest.warns(FutureWarning):
-        thread = e.no_arg.emit(value, asynchronous=True)
-    mock.assert_called_once()
-    assert Signal.current_emitter() is e.no_arg
-
-    # dude, you have to wait.
-    assert not a
-
-    if thread:
-        thread.join()
-    assert a == [value]
-    assert not Signal.current_emitter()
-
-
 def test_sig_unavailable():
     """In some cases, signature.inspect() fails on a callable, (many builtins).
 
@@ -1015,20 +986,3 @@ def test_signal_order():
 
     mock1.assert_has_calls([call(1), call(10)])
     mock2.assert_has_calls([call(1), call(10)])
-
-
-def test_double_emmision_error():
-    s = SignalInstance(raise_on_emit_during_emission=True)
-
-    i = 0
-
-    def callback():
-        nonlocal i
-        if i == 0:
-            s.emit()
-        i += 1
-
-    s.connect(callback)
-
-    with pytest.raises(EmitLoopError):
-        s.emit()


### PR DESCRIPTION
@Czaki, here is a a possible alternative.  it's quite similar to what you had, but allows for adding to the emit queue inside of a callback during emission.  

one side observation, and perhaps this is a reason *for* your approach of disallowing reemission, is this test, where we make no special attempt to prevent a recursion error

```python
def test_double_emmision_error():
    s = SignalInstance()

    def callback():
        s.emit()

    s.connect(callback)
    s.emit()
```

on main, that will fail eventually with a recursion error. On this PR, that somehow happily goes on forever, and python never raises a recursion error... it feels like we should still be able to catch that error, but i'm not sure how